### PR TITLE
Fix for Rails 3.2 pdf mime type warning.

### DIFF
--- a/lib/prawn-rails/engine.rb
+++ b/lib/prawn-rails/engine.rb
@@ -2,6 +2,6 @@ require "prawn-rails/prawn_handler"
 module PrawnRails
   class Engine < Rails::Engine
     ActionView::Template.register_template_handler(:prawn,PrawnRails::PrawnHandler)
-    Mime::Type.register "application/pdf", :pdf
+    Mime::Type.register_alias("application/pdf", :pdf) unless Mime::Type.lookup_by_extension(:pdf)
   end
 end


### PR DESCRIPTION
Updated for Rails 3.2
