### PR TITLE
do not create the first page to allow customization

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -37,6 +37,7 @@ Removes the html tags from a string
  
 	**hello.pdf.prawn**
 	
+		pdf.start_new_page :size => "A4"
 		pdf.text hello world
   
 2. ** Using Active Record **

--- a/lib/prawn-rails/prawn_handler.rb
+++ b/lib/prawn-rails/prawn_handler.rb
@@ -8,7 +8,7 @@ module PrawnRails
     end
     
     def call(template)
-      "pdf = ::Prawn::Document.new();" +
+      "pdf = ::Prawn::Document.new(:skip_page_creation => true);" +
       template.source +
       ";self.output_buffer=pdf.render;"
     end


### PR DESCRIPTION
Skipping the first page creation allows users to specify parameters like page size or margins.

It breaks compatibility but I think it should be done.

It would fix #1.
