### PR TITLE
prawn has extracted out prawn-table into a separate gem

### DIFF
--- a/lib/prawn-rails/document.rb
+++ b/lib/prawn-rails/document.rb
@@ -1,4 +1,5 @@
-require "prawn"
+require 'prawn'
+require 'prawn/table'
 
 module PrawnRails
   # This derives from Prawn::Document in order to override defaults. Note

--- a/prawn-rails.gemspec
+++ b/prawn-rails.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir["test/**/*"]
 
   s.add_dependency "prawn"
+  s.add_dependency "prawn-table"
   s.add_dependency "rails", ">= 3.1.0"
   s.add_development_dependency "sqlite3"
 end


### PR DESCRIPTION
add prawn-table gem as a dependency, and make sure that its included in `document.rb`
