### PR TITLE
Allow the filename of the PDF to be configured

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,7 +1,7 @@
 # Prawn-Rails [![Gem Version](https://badge.fury.io/rb/prawn-rails.svg)](http://badge.fury.io/rb/prawn-rails)
 
 ## Dependencies
- 
+
 * prawn > 0.0.12
 * prawn-table
 * Rails 3.0x
@@ -11,35 +11,41 @@
 1.Add to the Rails Gemfile
 
 	gem 'prawn-rails'
-		
-to the Rails Gemfile  
-`prawn` and `prawn-table` is a dependency so no need to mention it in the projects Gemfile  
-but can mention a specific version if your Gemfile, if you want   
+
+to the Rails Gemfile
+`prawn` and `prawn-table` is a dependency so no need to mention it in the projects Gemfile
+but can mention a specific version if your Gemfile, if you want
 
 ## Usage
-Create a view with `pdf` as format and `prawn` as handler 
+Create a view with `pdf` as format and `prawn` as handler
 so filename should look like `example.pdf.prawn`
 
-we provide a helper called `prawn_document` 
-it builds a PrawnRails::Document with default options. Can override with `page_size` and `page_layout` 
-example contents of `example.pdf.prawn` 
+we provide a helper called `prawn_document`
+it builds a PrawnRails::Document with default options. Can override with `page_size` and `page_layout`
+example contents of `example.pdf.prawn`
 
     prawn_document(:page_layout => :landscape) do |pdf|
       pdf.text "Hello World"
     end
 
-No need to call `pdf.render`, it is called by `prawn_document` 
+No need to call `pdf.render`, it is called by `prawn_document`
 
 Your available to use all prawn document methods like `pdf.text` `pdf.font_size` and also
 block like `pdf.font(FONT_NAME,opts) do
 pdf.XXXX
 end`
 
+If you want to customize the name of the file should a user try to save it, you can specify the filename in your action:
+
+    def show
+      @filename = 'my_report.pdf'
+    end
+
 For more documentation go to [the manual](http://prawnpdf.org/manual.pdf)
 
 ### Build in helpers
 * *html_strip(html)*
-Removes the html tags from a string	 
+Removes the html tags from a string
 
 ### Default configuration
 
@@ -51,20 +57,20 @@ Add a `prawn-rails.rb` config to your Rails app under `config/initializers` like
       config.skip_page_creation = false
     end
 
-by default `page_layout` is portrait and `page_size` is "A4" 
-also `skip_page_creation` is set to false by default, if it is set to true 
-then have to create the first page yourself for eg. 
+by default `page_layout` is portrait and `page_size` is "A4"
+also `skip_page_creation` is set to false by default, if it is set to true
+then have to create the first page yourself for eg.
 
     pdf.start_new_page size: "A4", page_layout: :landscape
 
 ## Examples
- 
+
 1. **Hello World**
- 
+
 	**hello.pdf.prawn**
-	
+
 		pdf.text hello world
-  
+
 2. ** Using Active Record **
 
 	**myproducts.pdf.prawn**
@@ -80,12 +86,12 @@ then have to create the first page yourself for eg.
 2. Simple Html to PDF ?
 3. Any Other requested
 
-## thx to 
-@rwilliams 
+## thx to
+@rwilliams
 @sigmike
 @smber1
 @iffyuva
 
 ## Dev Notes
 Gem works with any rails 3.0 version and ruby but for development It should be atlest Rails 3.1 (for the testing env)
-I'll try to fix that 
+I'll try to fix that

--- a/lib/prawn-rails/renderer.rb
+++ b/lib/prawn-rails/renderer.rb
@@ -3,7 +3,12 @@ require "prawn-rails/document"
 module PrawnRails
   class Renderer
     def self.call(template)
-      template.source.strip
+      %{
+        @filename ||= "\#{controller.action_name}.pdf"
+        controller.response.headers['Content-Disposition'] = "inline; filename=\\\"\#{@filename}\\\""
+
+        #{template.source.strip}
+      }
     end
   end
 end


### PR DESCRIPTION
Setting @filename in the action allows you to specify the name the file should be downloaded as, should a use try to save the PDF.

I'm not sure why, but it seems to be common to have `call` return a string, otherwise I don't believe the `controller` is available. I looked to [csv_shaper](https://github.com/paulspringett/csv_shaper/blob/45d06d3ecca845e8d9ef90b04a94ade12ae3196d/lib/csv_shaper_template.rb#L25-L37) for reference as they have a similar feature and that's how they handle it.