### PR TITLE
Set PDF title metadata to @filename

### DIFF
--- a/lib/prawn-rails/rails_helper.rb
+++ b/lib/prawn-rails/rails_helper.rb
@@ -4,7 +4,10 @@ module PrawnRails
   module RailsHelper
     def prawn_document(options={})
       options.reverse_merge!(:page_layout => PrawnRails.config.page_layout,
-                             :page_size => PrawnRails.config.page_size)
+                             :page_size => PrawnRails.config.page_size,
+                             :info => {
+                               :Title => @filename.sub(/\.(p|P)(d|D)(f|F)$/, '')
+                             })
 
       options.reverse_merge!(:skip_page_creation => true) if PrawnRails.config.skip_page_creation
 


### PR DESCRIPTION
The browser tab title is taken from the PDF documents Title metadata attribute. This now sets the Title attribute of the metadata based on the @filename without the file extension.