### PR TITLE
Require any installed prawn extensions

### DIFF
--- a/lib/prawn-rails/document.rb
+++ b/lib/prawn-rails/document.rb
@@ -1,7 +1,7 @@
 require 'prawn'
 require 'prawn-rails/extension'
 
-Gem.loaded_specs.select{|spec_name| spec_name.starts_with?('prawn-')}.map(&:name).each do |gem_name|
+Gem.loaded_specs.select{|spec_name| spec_name.starts_with?('prawn-')}.each do |gem_name|
   next if gem_name == 'prawn-rails' # Prevent circular loading
   require gem_name.gsub('-', '/')
 end

--- a/lib/prawn-rails/document.rb
+++ b/lib/prawn-rails/document.rb
@@ -1,7 +1,8 @@
 require 'prawn'
-require 'prawn_rails/extension'
+require 'prawn-rails/extension'
 
 Gem.loaded_specs.select{|s| s.name.starts_with?('prawn-')}.map(&:name).each do |gem_name|
+  next if gem_name == 'prawn-rails' # Prevent circular loading
   require gem_name.gsub('-', '/')
 end
 

--- a/lib/prawn-rails/document.rb
+++ b/lib/prawn-rails/document.rb
@@ -1,7 +1,7 @@
 require 'prawn'
 require 'prawn-rails/extension'
 
-Gem.loaded_specs.select{|spec_name| spec_name.starts_with?('prawn-')}.each do |gem_name|
+Gem.loaded_specs.keys.select{|spec_name| spec_name.starts_with?('prawn-')}.each do |gem_name|
   next if gem_name == 'prawn-rails' # Prevent circular loading
   require gem_name.gsub('-', '/')
 end

--- a/lib/prawn-rails/document.rb
+++ b/lib/prawn-rails/document.rb
@@ -1,6 +1,9 @@
-require 'prawn'
-require 'prawn/table'
-require "prawn-rails/extension"
+Gem::Specifcation.find_all{|s| s.name =~ /prawn/}.map(&:name).each do |gem_name|
+  case gem_name
+  when 'prawn-rails' then require 'prawn-rails/extension'
+  else require gem_name.gsub('-', '/')
+  end
+end
 
 module PrawnRails
 

--- a/lib/prawn-rails/document.rb
+++ b/lib/prawn-rails/document.rb
@@ -1,7 +1,7 @@
 require 'prawn'
 require 'prawn-rails/extension'
 
-Gem.loaded_specs.select{|s| s.name.starts_with?('prawn-')}.map(&:name).each do |gem_name|
+Gem.loaded_specs.select{|spec_name| spec_name.starts_with?('prawn-')}.map(&:name).each do |gem_name|
   next if gem_name == 'prawn-rails' # Prevent circular loading
   require gem_name.gsub('-', '/')
 end

--- a/lib/prawn-rails/document.rb
+++ b/lib/prawn-rails/document.rb
@@ -3,7 +3,12 @@ require 'prawn-rails/extension'
 
 Gem.loaded_specs.keys.select{|spec_name| spec_name.starts_with?('prawn-')}.each do |gem_name|
   next if gem_name == 'prawn-rails' # Prevent circular loading
-  require gem_name.gsub('-', '/')
+  begin
+    require gem_name.gsub('-', '/')
+  rescue LoadError => e
+    puts e
+    puts e.backtrace
+  end
 end
 
 module PrawnRails

--- a/lib/prawn-rails/document.rb
+++ b/lib/prawn-rails/document.rb
@@ -1,8 +1,8 @@
-Gem::Specifcation.find_all{|s| s.name =~ /prawn/}.map(&:name).each do |gem_name|
-  case gem_name
-  when 'prawn-rails' then require 'prawn-rails/extension'
-  else require gem_name.gsub('-', '/')
-  end
+require 'prawn'
+require 'prawn_rails/extension'
+
+Gem.loaded_specs.select{|s| s.name.starts_with?('prawn-')}.map(&:name).each do |gem_name|
+  require gem_name.gsub('-', '/')
 end
 
 module PrawnRails


### PR DESCRIPTION
This will search the loaded `Gem::Specification` for anything that matches the name `prawn` and require it as appropriate when loading `prawn-rails`.  This assumes that extensions, other than `prawn-rails`, are named in a particular fashion (such that the gem is `prawn-<extension>` and is required with `require prawn/<extension>`), but I have only tested and verified that it works with `prawn-emoji` and `prawn-table`.

Closes #28.