### PR TITLE
Fix deprecation warnings on Rails 6

### DIFF
--- a/lib/prawn-rails/renderer.rb
+++ b/lib/prawn-rails/renderer.rb
@@ -4,7 +4,7 @@ module PrawnRails
   class Renderer
 
     ### WARNING: BE VERY CAREFUL IF EDITING THIS METHOD
-    def self.call(template)
+    def self.call(template, source = nil)
       %{
         @filename ||= "\#{controller.action_name}.pdf"
 
@@ -12,7 +12,7 @@ module PrawnRails
           controller.response.headers['Content-Disposition'] = "inline; filename=\\\"\#{@filename}\\\""
         end
 
-        #{template.source.strip}
+        #{(source || template.source).strip}
       }
     end
 


### PR DESCRIPTION
Rails 6 RC1 changed the way handlers are called in https://github.com/rails/rails/commit/28f88e0074. It looks like we should prefer using the second `source` argument when it's given. There are similar patches in in [Haml](https://github.com/haml/haml/pull/1008) and [Temple](https://github.com/judofyr/temple/pull/121/files). 

This patch will maintain backwards compatibility with earlier versions of Rails. All tests are passing ✅. Let me know if there's anything else I can do to help. I'm open to any feedback you have.