### PR TITLE
Depend on railties instead of rails

### DIFF
--- a/prawn-rails.gemspec
+++ b/prawn-rails.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "prawn"
   s.add_dependency "prawn-table"
-  s.add_dependency "rails", ">= 3.1.0"
+  s.add_dependency "railties", ">= 3.1.0"
 
   s.add_development_dependency "pdf-reader"
   s.add_development_dependency 'rake'


### PR DESCRIPTION
This avoids pulling in all Rails dependencies even if they are not needed (such as activejob, actioncable etc.)