### PR TITLE
Add ostruct as dependency

### DIFF
--- a/prawn-rails.gemspec
+++ b/prawn-rails.gemspec
@@ -26,6 +26,10 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'minitest'
   s.add_development_dependency 'pry'
 
+  if RUBY_VERSION.to_f >= 3.3
+    s.add_dependency "ostruct"
+  end
+
   if RUBY_VERSION.to_f >= 3.1
     s.add_development_dependency 'matrix'
   end


### PR DESCRIPTION
ostruct will no longer be part of the standard library with Ruby 3.5. Not having this in the dependency list will trigger a deprecation message beginning with Ruby 3.3.5

Fixes #49